### PR TITLE
update some user messages for clarity

### DIFF
--- a/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/command/UploadCommand.java
+++ b/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/command/UploadCommand.java
@@ -93,7 +93,7 @@ public class UploadCommand extends AbstractClientCommand {
 
     val warn = isForce && exists;
     if (warn) {
-      terminal.printWarn("Object %s exists and --force specified. Overwritting...", objectId);
+      terminal.printWarn("Object %s exists and --force specified. Overwriting...", objectId);
     }
 
     terminal.printf("Uploading object: '%s' using the object id %s%n", file, objectId);

--- a/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/download/DownloadStateStore.java
+++ b/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/download/DownloadStateStore.java
@@ -131,7 +131,7 @@ public class DownloadStateStore {
       File partFile = new File(getObjectStateDir(stateDir, objectId), getPartName(part));
       Files.copy(new ByteArrayInputStream(content), partFile.toPath());
     } catch (IOException e) {
-      log.error("Fail to create meta file", e);
+      log.error("Failed to create meta file {} ", stateDir.getAbsolutePath(), e);
       throw new NotRetryableException(e);
     }
   }

--- a/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/exception/AmazonS3RetryableResponseErrorHandler.java
+++ b/dcc-storage-client/src/main/java/org/icgc/dcc/storage/client/exception/AmazonS3RetryableResponseErrorHandler.java
@@ -49,6 +49,11 @@ public class AmazonS3RetryableResponseErrorHandler extends DefaultResponseErrorH
       log.warn("Server error. Stop processing: {}", response.getStatusText());
       throw new NotResumableException(new IOException("Amazon S3 error: "
           + IOUtils.toString(response.getBody())));
+    case FORBIDDEN:
+      log.warn("FORBIDDEN response code received");
+      throw new NotRetryableException(new IOException(
+          "Amazon S3 error: Access refused by object store. Confirm request host is on permitted list"
+              + IOUtils.toString(response.getBody())));
     default:
       log.warn("Retryable exception: {}", response.getStatusText());
       throw new RetryableException(new IOException("Amazon S3 error: "


### PR DESCRIPTION
specifically handle status code 403 from Amazon S3 - provide hint that client might not be running from AWS EC2 instance
- this is really a trivial change that also doubles as a test case for figuring out why Jenkins build is using 0.0.22-SNAPSHOT as a build release version
