### PR TITLE
swagger docs and health endpoint

### DIFF
--- a/score-server/pom.xml
+++ b/score-server/pom.xml
@@ -93,6 +93,18 @@ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF S
       <artifactId>spring-retry</artifactId>
     </dependency>
 
+    <!-- Swagger -->
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger-ui</artifactId>
+      <version>2.8.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.springfox</groupId>
+      <artifactId>springfox-swagger2</artifactId>
+      <version>2.8.0</version>
+    </dependency>
+
     <!-- Amazon -->
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SecurityConfig.java
@@ -93,8 +93,11 @@ public class SecurityConfig extends ResourceServerConfigurerAdapter {
     http
       .authorizeRequests()
       .antMatchers("/health").permitAll()
+      .antMatchers("/actuator/health").permitAll()
       .antMatchers("/upload/**").permitAll()
       .antMatchers("/download/**").permitAll()
+      .antMatchers("/swagger**", "/swagger-resources/**", "/v2/api**", "/webjars/**")
+      .permitAll()
       .and()
       
       .authorizeRequests()

--- a/score-server/src/main/java/bio/overture/score/server/config/SwaggerConfig.java
+++ b/score-server/src/main/java/bio/overture/score/server/config/SwaggerConfig.java
@@ -1,0 +1,61 @@
+package bio.overture.score.server.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.paths.RelativePathProvider;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import static springfox.documentation.builders.RequestHandlerSelectors.basePackage;
+
+@EnableSwagger2
+@Configuration
+public class SwaggerConfig {
+
+  @Value("${server.version:1.0}")
+  private String serverVersion;
+
+  @Value("${swagger.alternateUrl:/swagger}")
+  @Getter
+  private String alternateSwaggerUrl;
+
+  // default is empty
+  @Value("${swagger.host:}")
+  private String swaggerHost;
+
+  // default is empty
+  @Value("${swagger.basePath:}")
+  private String basePath;
+
+  @Bean
+  public Docket api() {
+    return new Docket(DocumentationType.SWAGGER_2)
+      .apiInfo(apiInfo())
+      .select()
+      .apis(basePackage("bio.overture.score.server.controller"))
+      .build()
+      .host(swaggerHost)
+      .pathProvider(
+        new RelativePathProvider(null) {
+          @Override
+          public String getApplicationBasePath() {
+            return basePath;
+          }
+        });
+  }
+
+  private ApiInfo apiInfo() {
+    return new ApiInfoBuilder()
+      .title("Score API")
+      .description(
+        "Score API reference for developers.")
+      .version(serverVersion)
+      .build();
+  }
+
+}

--- a/score-server/src/main/java/bio/overture/score/server/controller/ListingController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/ListingController.java
@@ -24,6 +24,7 @@ import bio.overture.score.server.repository.ListingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @Component
@@ -33,7 +34,7 @@ public class ListingController {
   @Autowired
   private ListingService listingService;
 
-  @RequestMapping("/listing")
+  @RequestMapping(value = "/listing", method = RequestMethod.GET)
   public List<ObjectInfo> list() {
     return listingService.getListing();
   }


### PR DESCRIPTION
- Adds springfox as Swagger provider.
- Allows actuator health endpoint to be hit without auth