### PR TITLE
Score no such key issue #324

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,6 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
-                    branch 'score_NoSuchKey_issue_#324'
                 }
             }
             steps {
@@ -131,7 +130,6 @@ pipeline {
                     branch 'develop'
                     branch 'main'
                     branch 'test*'
-                    branch 'score_NoSuchKey_issue_#324'
                 }
             }
             parallel {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
                     branch 'develop'
                     branch 'master'
                     branch 'test*'
+                    branch 'score_NoSuchKey_issue_#324'
                 }
             }
             steps {
@@ -130,6 +131,7 @@ pipeline {
                     branch 'develop'
                     branch 'main'
                     branch 'test*'
+                    branch 'score_NoSuchKey_issue_#324'
                 }
             }
             parallel {

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadStateStore.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadStateStore.java
@@ -142,6 +142,10 @@ public class S3UploadStateStore implements UploadStateStore {
         return MAPPER.readValue(inputStream, ObjectSpecification.class);
       }
     } catch (AmazonServiceException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
+        log.warn("Key doesn't exist. Assuming it was deleted.");
+        throw e; // if object keys not found during any step in finalization - assume it is deleted - error rethrown to be caught by the caller.
+      }
       if (e.isRetryable()) {
         throw new RetryableException(e);
       } else {


### PR DESCRIPTION
The final step (a call to the finalizeUpload() method) of the upload command deletes all the uploaded parts of the file. But while the finalizing of the uploaded parts is still in progress score client keeps retrying the the call to finalizeUpload() and since the uploaded parts are being deleted a '404 Not found NoSuchKey' response is returned from Amazon S3. 
As a '404 Not found' indicates the parts have been or are being deleted, which is what the method is supposed to do, a retried call to finalizeUpload() will not return an exception.