### PR TITLE
Renamed the constant ICGCFS to SCOREFS

### DIFF
--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
@@ -43,7 +43,7 @@ public class StorageFileStore extends FileStore {
 
   @Override
   public String name() {
-    return "icgc";
+    return "score";
   }
 
   @Override

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
@@ -24,11 +24,11 @@ import java.nio.file.attribute.FileStoreAttributeView;
 
 public class StorageFileStore extends FileStore {
 
-  public static final String ICGCFS = "icgcfs";
+  public static final String SCOREFS = "scorefs";
 
   @Override
   public String type() {
-    return ICGCFS;
+    return SCOREFS;
   }
 
   @Override


### PR DESCRIPTION
**Rename the Constant:** #420 

The constant ICGCFS was renamed to SCOREFS. This means anywhere ICGCFS was used, it is now replaced by SCOREFS and The value assigned to the constant was changed from "icgcfs" to "scorefs" and the return statement was modified to return the new constant SCOREFS instead of the old constant ICGCFS 