### PR TITLE
change URI scheme from icgc:// to score:// 

### DIFF
--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystemProvider.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystemProvider.java
@@ -70,7 +70,7 @@ public class StorageFileSystemProvider extends ReadOnlyFileSystemProvider {
 
   @Override
   public String getScheme() {
-    return "icgc";
+    return "score";
   }
 
   @Override

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystems.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystems.java
@@ -38,7 +38,7 @@ public class StorageFileSystems {
   public StorageFileSystem newFileSystem(@NonNull StorageContext context, Map<String, ?> env)
       throws IOException, URISyntaxException {
     val provider = new StorageFileSystemProvider(context);
-    val uri = new URI("icgc://storage");
+    val uri = new URI("score://storage");
 
     return (StorageFileSystem) provider.newFileSystem(uri, env);
   }


### PR DESCRIPTION
Updating the URI scheme- #421 

**URI Change:** The URI scheme icgc was changed to score. This scheme is an arbitrary string value used to identify the type of filesystem. Changing it ensures that the new naming convention is consistent throughout the codebase.
**Return Value Change:** The method in StorageFileSystemProvider.java that returns "icgc" now returns "score", ensuring consistency with the new URI scheme.