### PR TITLE
Remove wiki reference comment in DownloadManifest.java

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
+++ b/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
@@ -22,12 +22,6 @@ import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-
-/**
- * See
- * https://wiki.oicr.on.ca/display/DCCSOFT/Uniform+metadata+JSON+document+for+ICGC+Data+Repositories#
- * UniformmetadataJSONdocumentforICGCDataRepositories-Manifestfileformatfordownloader
- */
 @Value
 public class DownloadManifest {
   @NonNull private final List<ManifestEntry> entries;


### PR DESCRIPTION
This PR removes an outdated comment block that references a private wiki, which contains no additional information beyond what is already in the code with reference to #423 

Also, A search across the codebase confirmed that this is the only instance of such a wiki reference. No other references were found.