### PR TITLE
Update token header key from ICGC to SCORe

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
+++ b/score-client/src/main/java/bio/overture/score/client/manifest/DownloadManifest.java
@@ -22,12 +22,6 @@ import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-
-/**
- * See
- * https://wiki.oicr.on.ca/display/DCCSOFT/Uniform+metadata+JSON+document+for+ICGC+Data+Repositories#
- * UniformmetadataJSONdocumentforICGCDataRepositories-Manifestfileformatfordownloader
- */
 @Value
 public class DownloadManifest {
   @NonNull private final List<ManifestEntry> entries;

--- a/score-client/src/main/java/bio/overture/score/client/storage/AbstractStorageService.java
+++ b/score-client/src/main/java/bio/overture/score/client/storage/AbstractStorageService.java
@@ -28,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public abstract class AbstractStorageService implements StorageService {
 
-  private static final String ICGC_TOKEN_KEY = "X-ICGC-TOKEN";
+  private static final String SCORE_TOKEN_KEY = "X-SCORE-TOKEN";
   private final DownloadStateStore downloadStateStore;
   private final RestTemplate dataTemplate;
   private final RetryTemplate retry;
@@ -54,7 +54,7 @@ public abstract class AbstractStorageService implements StorageService {
                       request -> {
                         request.getHeaders().set(HttpHeaders.RANGE, Parts.getHttpRangeValue(part));
                         String token = getEncryptedAccessToken().orElse("");
-                        request.getHeaders().set(ICGC_TOKEN_KEY, token);
+                        request.getHeaders().set(SCORE_TOKEN_KEY, token);
                       },
                       response -> {
                         try (HashingInputStream his =

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
@@ -43,7 +43,7 @@ public class StorageFileStore extends FileStore {
 
   @Override
   public String name() {
-    return "icgc";
+    return "score";
   }
 
   @Override

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileStore.java
@@ -24,11 +24,11 @@ import java.nio.file.attribute.FileStoreAttributeView;
 
 public class StorageFileStore extends FileStore {
 
-  public static final String ICGCFS = "icgcfs";
+  public static final String SCOREFS = "scorefs";
 
   @Override
   public String type() {
-    return ICGCFS;
+    return SCOREFS;
   }
 
   @Override

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystemProvider.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystemProvider.java
@@ -70,7 +70,7 @@ public class StorageFileSystemProvider extends ReadOnlyFileSystemProvider {
 
   @Override
   public String getScheme() {
-    return "icgc";
+    return "score";
   }
 
   @Override

--- a/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystems.java
+++ b/score-fs/src/main/java/bio/overture/score/fs/StorageFileSystems.java
@@ -38,7 +38,7 @@ public class StorageFileSystems {
   public StorageFileSystem newFileSystem(@NonNull StorageContext context, Map<String, ?> env)
       throws IOException, URISyntaxException {
     val provider = new StorageFileSystemProvider(context);
-    val uri = new URI("icgc://storage");
+    val uri = new URI("score://storage");
 
     return (StorageFileSystem) provider.newFileSystem(uri, env);
   }


### PR DESCRIPTION
This PR updates the token header key used in the codebase from **X-ICGC-TOKEN** to **X-SCORE-TOKEN**. Previously, the header key **X-ICGC-TOKEN** was utilized for sending authentication tokens in HTTP requests. This change aligns the code with using **X-SCORE-TOKEN** as the header key. Also we have removed the description from DownloadManifest.java as it's no longer in use.


With reference to ticket#6