### PR TITLE
Updated bucket names from oicr.icgc.test to score.data/score.state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,18 +76,18 @@ _ping_song_server:
 
 
 _setup-object-storage: 
-	@echo $(YELLOW)$(INFO_HEADER) "Setting up bucket oicr.icgc.test and heliograph" $(END)
-	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://oicr.icgc.test ; then \
+	@echo $(YELLOW)$(INFO_HEADER) "Setting up bucket score.data and heliograph" $(END)
+	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://score.data ; then \
 		echo $(YELLOW)$(INFO_HEADER) "Bucket already exists. Skipping creation..." $(END); \
 	else \
-		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 mb s3://oicr.icgc.test; \
+		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 mb s3://score.data; \
 	fi
-	@$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 cp /score-data/heliograph s3://oicr.icgc.test/data/heliograph
+	@$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 cp /score-data/heliograph s3://score.data/data/heliograph
 
 _destroy-object-storage:
-	@echo $(YELLOW)$(INFO_HEADER) "Removing bucket oicr.icgc.test" $(END)
-	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://oicr.icgc.test ; then \
-		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 rb s3://oicr.icgc.test --force; \
+	@echo $(YELLOW)$(INFO_HEADER) "Removing bucket score.data" $(END)
+	@if  $(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 ls s3://score.data ; then \
+		$(DOCKER_COMPOSE_CMD) run aws-cli --endpoint-url http://object-storage:9000 s3 rb s3://score.data --force; \
 	else \
 		echo $(YELLOW)$(INFO_HEADER) "Bucket does not exist. Skipping..." $(END); \
 	fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,8 +56,8 @@ services:
       SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
-      BUCKET_NAME_OBJECT: oicr.icgc.test
-      BUCKET_NAME_STATE: oicr.icgc.test
+      BUCKET_NAME_OBJECT: score.data
+      BUCKET_NAME_STATE: score.state
       COLLABORATORY_DATA_DIRECTORY: data
       METADATA_URL: http://song-server:8080
       S3_ENDPOINT:  http://object-storage:9000
@@ -138,7 +138,7 @@ services:
       AWS_SECRET_ACCESS_KEY: minio123
       AWS_DEFAULT_REGION: us-east-1
     volumes:
-      - "./docker/object-storage-init/data/oicr.icgc.test/data:/score-data:ro"
+      - "./docker/object-storage-init/data/score.data/data:/score-data:ro"
   song-server:
     image: ghcr.io/overture-stack/song-server:438c2c42
     environment:


### PR DESCRIPTION
https://github.com/overture-stack/score/issues/437

This PR updates the bucket names used in the codebase from **oicr.icgc.test** to **score.data** for **BUCKET_NAME_OBJECT** and from **oicr.icgc.test** to **score.state** for **BUCKET_NAME_STATE**. 

- [x] Updated the Makefile to reference the new bucket names.

- [x] Replaced all instances of oicr.icgc.test with score.data.

Previously, the buckets **oicr.icgc.test** were referenced in the configuration. This change aligns the code with using score.data and score.state as the new bucket names, reflecting recent updates in the storage infrastructure

Updated 