### PR TITLE
Update token header key from ICGC to SCORe

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/storage/AbstractStorageService.java
+++ b/score-client/src/main/java/bio/overture/score/client/storage/AbstractStorageService.java
@@ -28,7 +28,7 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public abstract class AbstractStorageService implements StorageService {
 
-  private static final String ICGC_TOKEN_KEY = "X-ICGC-TOKEN";
+  private static final String SCORE_TOKEN_KEY = "X-SCORE-TOKEN";
   private final DownloadStateStore downloadStateStore;
   private final RestTemplate dataTemplate;
   private final RetryTemplate retry;
@@ -54,7 +54,7 @@ public abstract class AbstractStorageService implements StorageService {
                       request -> {
                         request.getHeaders().set(HttpHeaders.RANGE, Parts.getHttpRangeValue(part));
                         String token = getEncryptedAccessToken().orElse("");
-                        request.getHeaders().set(ICGC_TOKEN_KEY, token);
+                        request.getHeaders().set(SCORE_TOKEN_KEY, token);
                       },
                       response -> {
                         try (HashingInputStream his =


### PR DESCRIPTION
https://github.com/overture-stack/score/issues/439

This PR updates the token header key used in the codebase from X-ICGC-TOKEN to X-SCORE-TOKEN. Previously, the header key X-ICGC-TOKEN was utilized for sending authentication tokens in HTTP requests. This change aligns the code with using X-SCORE-TOKEN as the header key. Also we have removed the description from DownloadManifest.java as it's no longer in use.
