### PR TITLE
Renaming the icgc references to SCORe

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/command/ViewCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/ViewCommand.java
@@ -84,7 +84,7 @@ public class ViewCommand extends RepositoryAccessCommand {
   public static final int MAX_FILENAME_LENGTH = 120;
 
   public static final String PROGRAM_NAME = "Score Client";
-  public static final String ICGC = "ICGC";
+  public static final String SCORE = "score";
 
   /** Options. */
   @Parameter(
@@ -274,7 +274,7 @@ public class ViewCommand extends RepositoryAccessCommand {
         builder
             .programName(PROGRAM_NAME)
             .version(VersionUtils.getScmInfo().get("git.commit.id.describe"))
-            .programId(ICGC)
+            .programId(SCORE)
             .commandLine(getCommandLine())
             .containedOnly(containedOnly)
             .useOriginalHeader(useOriginalHeader)

--- a/score-client/src/main/java/bio/overture/score/client/config/ClientProperties.java
+++ b/score-client/src/main/java/bio/overture/score/client/config/ClientProperties.java
@@ -14,7 +14,7 @@ public class ClientProperties {
   /** Constants. */
   private static final int DEFAULT_LIMIT = 10;
 
-  /** OAuth2 access token for ICGC authorization server */
+  /** OAuth2 access token for SCORe authorization server */
   private String accessToken;
 
   private String encryptedAccessToken;

--- a/score-client/src/main/java/bio/overture/score/client/slicing/SamFileBuilder.java
+++ b/score-client/src/main/java/bio/overture/score/client/slicing/SamFileBuilder.java
@@ -408,21 +408,21 @@ public class SamFileBuilder {
         new ArrayList<SAMProgramRecord>(pgRecords); // get returns an unmodifiable collection
 
     String id = programId == null ? "unknown" : programId;
-    val count = getIcgcProgramRecordCount(pgRecords);
+    val count = getProgramRecordCount(pgRecords);
     if (count > 0) {
       id = String.format("%s.%d", id, count + 1);
     }
-    SAMProgramRecord icgcClientRecord = new SAMProgramRecord(id);
-    if (programName != null) icgcClientRecord.setProgramName(programName);
-    if (commandLine != null) icgcClientRecord.setCommandLine(commandLine);
-    if (description != null) icgcClientRecord.setAttribute("DS", description);
-    if (version != null) icgcClientRecord.setAttribute("VN", version);
-    if (commandLine != null) icgcClientRecord.setCommandLine(commandLine);
-    newPgRecords.add(icgcClientRecord);
+    SAMProgramRecord clientRecord = new SAMProgramRecord(id);
+    if (programName != null) clientRecord.setProgramName(programName);
+    if (commandLine != null) clientRecord.setCommandLine(commandLine);
+    if (description != null) clientRecord.setAttribute("DS", description);
+    if (version != null) clientRecord.setAttribute("VN", version);
+    if (commandLine != null) clientRecord.setCommandLine(commandLine);
+    newPgRecords.add(clientRecord);
     return newPgRecords;
   }
 
-  private int getIcgcProgramRecordCount(List<SAMProgramRecord> pgRecords) {
+  private int getProgramRecordCount(List<SAMProgramRecord> pgRecords) {
     int count = 0;
     for (val pg : pgRecords) {
       if (pg.getId().substring(0, programId.length() - 1).equalsIgnoreCase(programId)) {


### PR DESCRIPTION
 Updated SAMFileBuilder in the ViewCommand to use "score" instead of "icgc" for SAMRecord headers, renamed related variables for better generic usage, updated comments in ClientProperties, and replaced ICGC references with "score" in ViewCommand.

Details:

- Renamed variables in SAMFileBuilder that included "icgc" in their names to be more generic:
- Updated variable names and their corresponding references to use more appropriate and descriptive names.
- Modified method getProgramRecordCount() and the clientRecord to reflect these changes.
- Updated the comment in ClientProperties:
Changed /** OAuth2 access token for ICGC authorization server */ to /** OAuth2 access token for SCORe authorization server */
-  Replaced ICGC variable and value with the string literal "score" in the ViewCommand:

**Impact:** This update affects the internal labeling and variable naming in the SAMFileBuilder and ViewCommand, making them more adaptable and removing hardcoded references to "icgc". It also updates documentation comments to reflect current usage. These changes do not impact the core functionality of the application. #442 