### PR TITLE
Removing ICGC support contact info currently which are inside the SCO…

### DIFF
--- a/score-client/Dockerfile
+++ b/score-client/Dockerfile
@@ -8,7 +8,7 @@
 # Banner @ https://goo.gl/Yyoc6R
 
 FROM       ubuntu:16.04
-MAINTAINER ICGC <dcc-support@icgc.org>
+MAINTAINER SCORe <>
 
 #
 # Update apt, add FUSE support and basic command line tools

--- a/score-client/Dockerfile
+++ b/score-client/Dockerfile
@@ -8,7 +8,6 @@
 # Banner @ https://goo.gl/Yyoc6R
 
 FROM       ubuntu:16.04
-MAINTAINER SCORe <>
 
 #
 # Update apt, add FUSE support and basic command line tools

--- a/score-client/src/main/java/bio/overture/score/client/command/VersionCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/VersionCommand.java
@@ -28,8 +28,6 @@ import org.springframework.stereotype.Component;
 public class VersionCommand extends AbstractClientCommand {
 
   /** Constants. */
-  private static final String SUPPORT_EMAIL = "";
-
   @Override
   public int execute() throws Exception {
     printTitle();

--- a/score-client/src/main/java/bio/overture/score/client/command/VersionCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/VersionCommand.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 public class VersionCommand extends AbstractClientCommand {
 
   /** Constants. */
-  private static final String SUPPORT_EMAIL = "dcc-support@icgc.org";
+  private static final String SUPPORT_EMAIL = "";
 
   @Override
   public int execute() throws Exception {
@@ -40,7 +40,6 @@ public class VersionCommand extends AbstractClientCommand {
   private void version() {
     terminal.println(terminal.label("  Version: ") + getVersion());
     terminal.println(terminal.label("  Built:   ") + getScmInfo().get("git.build.time"));
-    terminal.println(terminal.label("  Contact: ") + terminal.email(SUPPORT_EMAIL));
   }
 
   private String getVersion() {


### PR DESCRIPTION
Removed hardcoded ICGC support contact information from the SCORe CLI to ensure generic usability with any SCORe server.

Details:

- [x] Removed hardcoded contact email from the SCORe CLI.

- [x] Removed contact info logging from the version command.

- [x] Removed contact info from the Dockerfile.

These changes ensure that the CLI does not include built-in contact information, making it generically usable. In the future, any required contact information should be retrieved from the server. #443 