### PR TITLE
Eliminating Error messaging referencing ICGC

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
@@ -167,7 +167,7 @@ public class DownloadCommand extends RepositoryAccessCommand {
     if (manifestResource.isGnosManifest()) {
       throw new BadManifestException(
           format(
-              "Manifest '%s' looks like a GNOS-format manifest file. Please ensure you are using a tab-delimited text file",
+              "Manifest '%s' looks like a GNOS-format manifest file. Please ensure you are using a tab-delimited text file manifest",
               manifestResource.getValue()));
     }
     val manifest = manifestService.getDownloadManifest(manifestResource);

--- a/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java
@@ -167,8 +167,7 @@ public class DownloadCommand extends RepositoryAccessCommand {
     if (manifestResource.isGnosManifest()) {
       throw new BadManifestException(
           format(
-              "Manifest '%s' looks like a GNOS-format manifest file. Please ensure you are using a tab-delimited text file"
-                  + " manifest from https://dcc.icgc.org/repositories",
+              "Manifest '%s' looks like a GNOS-format manifest file. Please ensure you are using a tab-delimited text file",
               manifestResource.getValue()));
     }
     val manifest = manifestService.getDownloadManifest(manifestResource);


### PR DESCRIPTION
 Updated error messaging in DownloadCommand.java to remove references to ICGC and provide a more concise message.

**Details:**

Shortened the error message in score/score-client/src/main/java/bio/overture/score/client/command/DownloadCommand.java:
Updated the message to: "Please ensure you are using a tab-delimited text file manifest." #444 