### PR TITLE
Renaming the icgc reference to SCORe

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/command/MountCommand.java
+++ b/score-client/src/main/java/bio/overture/score/client/command/MountCommand.java
@@ -112,7 +112,7 @@ public class MountCommand extends RepositoryAccessCommand {
   @Parameter(
       names = "--options",
       description =
-          "The mount options of the file system (e.g. --options user_allow_other,allow_other,fsname=icgc,debug) "
+          "The mount options of the file system (e.g. --options user_allow_other,allow_other,fsname=score,debug) "
               + "in addition to those specified internally: "
               + INTERNAL_MOUNT_OPTIONS
               + ". See "


### PR DESCRIPTION
Updated directory mounting instructions and documentation link in MountCommand.java to reflect current naming conventions and documentation resources.

**Details:**

- [x] Updated example options in score/score-client/src/main/java/bio/overture/score/client/command/MountCommand.java:

- [x] Replaced fsname=icgc with fsname=score to reflect the updated naming convention.

These changes ensure that the example and documentation references are accurate and align with the latest standards and resources. #446 