### PR TITLE
Rephrasing the error handling messages

### DIFF
--- a/score-client/src/main/java/bio/overture/score/client/exception/ConnectivityResponseHandler.java
+++ b/score-client/src/main/java/bio/overture/score/client/exception/ConnectivityResponseHandler.java
@@ -34,16 +34,16 @@ public class ConnectivityResponseHandler extends DefaultResponseErrorHandler {
     switch (status) {
       case FORBIDDEN:
         log.warn(
-            "FORBIDDEN response code received. If you are trying to connect to the AWS S3 Repository, you need to be running ths ICGC client on an EC2 VM instance.");
+            "Connection to object storage refused, received response code FORBIDDEN.");
         throw notRetryableException(
-            "Amazon S3 error: FORBIDDEN: If you are trying to connect to the AWS S3 Repository, you need to be running ths ICGC client on an EC2 VM instance",
+            "Connection to object storage refused, received response code FORBIDDEN.",
             response);
 
       case REQUEST_TIMEOUT:
         log.warn(
-            "Unable to connect to repository endpoint. You need to be running on a compute node within the repository cloud. Or else your network connection is hinky.");
+            "Connection to object storage failed, request timed out.");
         throw notRetryableException(
-            "Cloud error: Access refused by object store. Confirm request host is on permitted list",
+            "Connection to object storage failed, request timed out.",
             response);
 
       default:


### PR DESCRIPTION
Simplified and updated error messaging in ConnectivityResponseHandler to remove outdated references and improve clarity.

Details:

- [x] Removed references to AWS and ICGC DCC repository errors from error messaging.

- [x] Updated error and log warning messages to be more concise and relevant to the current context:

- [x] Changed error message to: "Connection to object storage refused, received response code FORBIDDEN."

- [x] Changed log warning to: "Connection to object storage failed, request timed out."

These changes streamline the error handling messages, removing unnecessary details and focusing on the essential information.

**Impact:** This update affects only the error and log warning messages in ConnectivityResponseHandler and does not impact the application logic. #447 