### PR TITLE
Rename COLLABORATORY Strorage Profile to S3 in SCORe

### DIFF
--- a/score-core/src/main/java/bio/overture/score/core/model/StorageProfiles.java
+++ b/score-core/src/main/java/bio/overture/score/core/model/StorageProfiles.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 public enum StorageProfiles {
   AZURE("azure", "az"),
-  COLLABORATORY("collaboratory", "s3");
+  S3("s3", "s3");
 
   private final String profileKey;
   private final String profileValue;


### PR DESCRIPTION
**Summary:**
The COLLABORATORY Storage Profile, originally used to denote S3-like storage in SCORe, has been renamed to `S3` for clarity and consistency. This change affects both the `profileName` and `profileValue` used by the server and client.
**Details:**
Changed the profile from `COLLABORATORY("collaboratory", "s3")` to `S3("s3", "s3")` -- #463 