### PR TITLE
Remove @Profile Annotations from DownloadController and UploadController

### DIFF
--- a/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/DownloadController.java
@@ -26,7 +26,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -46,7 +45,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/download")
 @Slf4j
-@Profile({"prod", "default", "debug"})
 public class DownloadController {
 
   @Autowired DownloadService downloadService;

--- a/score-server/src/main/java/bio/overture/score/server/controller/UploadController.java
+++ b/score-server/src/main/java/bio/overture/score/server/controller/UploadController.java
@@ -31,7 +31,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -52,7 +51,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/upload")
 @Slf4j
-@Profile({"prod", "default", "debug"})
 public class UploadController {
 
   @Autowired UploadService uploadService;


### PR DESCRIPTION
### Summary
This PR removes the `@Profile` annotations from the `DownloadController` and `UploadController` classes in the SCORe codebase. These controllers were previously annotated with `@Profile({"prod", "default", "debug"})`, which included them only under certain profiles.

### Details
- **Removed**: `@Profile({"prod", "default", "debug"})` annotations from both `DownloadController` and `UploadController`.
- These controllers should always be included in the application context, regardless of the active profile. 
- This change simplifies the configuration by ensuring that these controllers are always available on the server.

### Additional Context
This change is part of an effort to streamline and simplify the configuration of the SCORe application, ensuring essential controllers are always active without relying on specific profiles. #473 