### PR TITLE
Remove Hardcoded URL in Benchmark Profile

### DIFF
--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -305,5 +305,4 @@ server:
 
 s3:
   secured: false
-  # Sinai Center
-  endpoint: http://www.cancercollaboratory.org:9081
+  endpoint:


### PR DESCRIPTION
**Summary**

This PR removes the hardcoded URL referencing "Sinai Center" and cancercollaboratory in the benchmark profile section of the configuration file. The endpoint value under the s3 section has been left blank, ensuring that it must be provided by anyone running a benchmark. This change enhances flexibility by allowing users to specify their own endpoint URL when necessary. #475 