### PR TITLE
Rename COLLABORATORY Strorage Profile to S3 in SCORe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ KeyczarTest.java
 HelperTest.java
 DownloadPartRequest.java
 
-# collaboratory
+# s3
 service.jks
 application-prod.properties
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -32,6 +32,6 @@ CMD mkdir -p  $SCORE_HOME $SCORE_LOGS \
     && java -Dlog.path=$SCORE_LOGS \
     -jar $JAR_FILE \
     --spring.config.location=classpath:/application.yml \
-    --spring.profiles.active=amazon,collaboratory,prod,secure
+    --spring.profiles.active=amazon,prod,secure
 
 #&& FOR_100_YEARS=$((100*365*24*60*60));while true;do sleep $FOR_100_YEARS;done

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -32,6 +32,6 @@ CMD mkdir -p  $SCORE_HOME $SCORE_LOGS \
     && java -Dlog.path=$SCORE_LOGS \
     -jar $JAR_FILE \
     --spring.config.location=classpath:/application.yml \
-    --spring.profiles.active=amazon,prod,secure
+    --spring.profiles.active=s3,prod,secure
 
 #&& FOR_100_YEARS=$((100*365*24*60*60));while true;do sleep $FOR_100_YEARS;done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       dockerfile: "$DOCKERFILE_NAME"
       target: server
     environment:
-      SPRING_PROFILES_ACTIVE: amazon,prod,secure
+      SPRING_PROFILES_ACTIVE: s3,prod,secure
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
       BUCKET_NAME_OBJECT: score.data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       dockerfile: "$DOCKERFILE_NAME"
       target: server
     environment:
-      SPRING_PROFILES_ACTIVE: amazon,collaboratory,prod,secure
+      SPRING_PROFILES_ACTIVE: amazon,prod,secure
       SERVER_PORT: 8080
       OBJECT_SENTINEL: heliograph
       BUCKET_NAME_OBJECT: score.data

--- a/score-client/src/main/java/bio/overture/score/client/config/ProfileConfig.java
+++ b/score-client/src/main/java/bio/overture/score/client/config/ProfileConfig.java
@@ -27,7 +27,7 @@ public class ProfileConfig {
   private String endpoint;
 
   @Autowired
-  @Value("${defaultProfile:collaboratory}")
+  @Value("${defaultProfile:s3}")
   private String defaultProfile;
 
   @Autowired

--- a/score-client/src/main/resources/application.yml
+++ b/score-client/src/main/resources/application.yml
@@ -71,7 +71,7 @@ token:
 
 
 isTest: false
-defaultProfile: collaboratory
+defaultProfile: s3
 
 ---
 

--- a/score-client/src/test/java/bio/overture/score/client/config/TestProfileConfig.java
+++ b/score-client/src/test/java/bio/overture/score/client/config/TestProfileConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
 public class TestProfileConfig {
 
   @Autowired
-  @Value("${defaultProfile:collaboratory}")
+  @Value("${defaultProfile:s3}")
   private String defaultProfile;
 
   @Bean

--- a/score-client/src/test/resources/application.yml
+++ b/score-client/src/test/resources/application.yml
@@ -70,7 +70,7 @@ token:
 
 
 isTest: true
-defaultProfile: collaboratory
+defaultProfile: s3
 
 ---
 ###############################################################################

--- a/score-core/src/main/java/bio/overture/score/core/model/StorageProfiles.java
+++ b/score-core/src/main/java/bio/overture/score/core/model/StorageProfiles.java
@@ -5,7 +5,7 @@ import java.util.Set;
 
 public enum StorageProfiles {
   AZURE("azure", "az"),
-  COLLABORATORY("collaboratory", "s3");
+  S3("s3", "s3");
 
   private final String profileKey;
   private final String profileValue;

--- a/score-server/src/main/conf/application.properties
+++ b/score-server/src/main/conf/application.properties
@@ -22,4 +22,4 @@
 # s3.secretKey=
 # server.ssl.key-store-password=
 # s3.masterEncryptionKeyId=
-# collaboratory.bucket.name=
+# s3.bucket.name=

--- a/score-server/src/main/java/bio/overture/score/server/repository/UploadCleanupService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/UploadCleanupService.java
@@ -40,10 +40,10 @@ import org.springframework.stereotype.Service;
 public class UploadCleanupService {
 
   /** Configuration. */
-  @Value("${collaboratory.data.directory}")
+  @Value("${s3.data.directory}")
   private String dataDir;
 
-  @Value("${collaboratory.upload.expiration}")
+  @Value("${s3.upload.expiration}")
   private int expiration;
 
   /** Dependencies. */

--- a/score-server/src/main/java/bio/overture/score/server/repository/azure/AzureURLGenerator.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/azure/AzureURLGenerator.java
@@ -49,7 +49,7 @@ public class AzureURLGenerator implements URLGenerator {
   @Value("${bucket.policy.download}")
   private String downloadPolicy;
 
-  @Value("${collaboratory.download.expiration}")
+  @Value("${s3.download.expiration}")
   private int expiration;
 
   @Autowired private CloudBlobContainer azureContainer;

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3DownloadService.java
@@ -70,10 +70,10 @@ public class S3DownloadService implements DownloadService {
   private static final String PUBLISHED_ANALYSIS_STATE = "PUBLISHED";
 
   /** Configuration. */
-  @Value("${collaboratory.data.directory}")
+  @Value("${s3.data.directory}")
   private String dataDir;
 
-  @Value("${collaboratory.download.expiration}")
+  @Value("${s3.download.expiration}")
   private int expiration;
 
   @Value("${object.sentinel}")
@@ -210,7 +210,7 @@ public class S3DownloadService implements DownloadService {
   private String getObjectMd5(ObjectMetadata metadata) {
     val contentMd5 = metadata.getContentMD5();
     if (contentMd5 != null) {
-      return  MD5s.toHex(contentMd5);
+      return MD5s.toHex(contentMd5);
     }
     val userMetadataMd5 =
         metadata.getUserMetaDataOf(s3config.getCustomMd5Property()); // get literal from config

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3ListingService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3ListingService.java
@@ -48,13 +48,8 @@ public class S3ListingService implements ListingService {
   @Value("${bucket.name.object}")
   private String bucketName;
 
-  @Value("${collaboratory.data.directory}")
+  @Value("${s3.data.directory}")
   private String dataDir;
-
-  // @Value("${collaboratory.bucket.poolsize}")
-  // private int bucketPoolSize;
-  // @Value("${collaboratory.bucket.keysize}")
-  // private int bucketKeySize;
 
   /** Dependencies. */
   @Autowired private AmazonS3 s3;

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadService.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadService.java
@@ -62,10 +62,10 @@ public class S3UploadService implements UploadService {
   private static final String UNPUBLISHED_ANALYSIS_STATE = "UNPUBLISHED";
 
   /** Configuration. */
-  @Value("${collaboratory.data.directory}")
+  @Value("${s3.data.directory}")
   private String dataDir;
 
-  @Value("${collaboratory.upload.expiration}")
+  @Value("${s3.upload.expiration}")
   private int expiration;
 
   @Value("${metadata.useLegacyMode:false}")

--- a/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadStateStore.java
+++ b/score-server/src/main/java/bio/overture/score/server/repository/s3/S3UploadStateStore.java
@@ -76,10 +76,10 @@ public class S3UploadStateStore implements UploadStateStore {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /** Configuration. */
-  @Value("${collaboratory.data.directory}")
+  @Value("${s3.data.directory}")
   private String dataDir;
 
-  @Value("${collaboratory.upload.directory}")
+  @Value("${s3.upload.directory}")
   private String uploadDir;
 
   /** Dependencies. */

--- a/score-server/src/main/resources/application.yml
+++ b/score-server/src/main/resources/application.yml
@@ -33,6 +33,9 @@ server:
 s3:
   secured: true
   sigV4Enabled: true
+  upload.directory: upload
+  upload.expiration: 6
+  data.directory: data
 
   # custom meta property with md5 hash, unused when upload state files are available (default behaviour)
   # customMd5Property: md5chksum
@@ -56,12 +59,6 @@ bucket:
 
 object:
   sentinel: heliograph
-
-collaboratory:
-  upload.directory: upload
-  upload.expiration: 6
-  data.directory: data
-
   # COL-131: Change pre-signed URLs TTL to 1 day max
   download.expiration: 1
 


### PR DESCRIPTION
Summary:
The COLLABORATORY Storage Profile, originally used to denote S3-like storage in SCORe, has been renamed to S3 for clarity and consistency. This change affects both the profileName and profileValue used by the server and client.
Details:
Changed the profile from COLLABORATORY("collaboratory", "s3") to S3("s3", "s3") -- https://github.com/overture-stack/score/issues/463